### PR TITLE
Colorize all visible editors instead of active one

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
   "dependencies": {
     "@types/color-convert": "^2.0.0",
     "color-convert": "^2.0.1",
-    "just-debounce": "^1.1.0",
     "murmurhash": "^2.0.0"
   }
 }

--- a/src/colorize.ts
+++ b/src/colorize.ts
@@ -15,16 +15,16 @@ function colorIndexOfSymbol(symbolName: string, symbolIndex: number): number {
 	}
 }
 
-export async function colorize(editor: vscode.TextEditor): Promise<void> {
+export async function colorize(editor: vscode.TextEditor): Promise<boolean> {
 	const uri = editor.document.uri
-	if (uri == null || ignoredLanguages.has(editor.document.languageId)) { return }
+	if (uri == null || ignoredLanguages.has(editor.document.languageId)) { return true }
 	const stat = await vscode.workspace.fs.stat(uri)
-	if (stat.size > bigFileSize) { return }
+	if (stat.size > bigFileSize) { return true }
 	const legend: vscode.SemanticTokensLegend | undefined = await vscode.commands.executeCommand('vscode.provideDocumentSemanticTokensLegend', uri)
 	const tokensData: vscode.SemanticTokens | undefined = await vscode.commands.executeCommand('vscode.provideDocumentSemanticTokens', uri)
 	vscode.window.activeColorTheme
 	rangeLists = colors.map(_ => [])
-	if (tokensData == null || legend == null) { return }
+	if (tokensData == null || legend == null) { return false }
 	const rangesBySymbolName = rangesByName(tokensData, legend, editor)
 	Object.keys(rangesBySymbolName).forEach((name, index) => {
 		const ranges = rangesBySymbolName[name]
@@ -35,4 +35,6 @@ export async function colorize(editor: vscode.TextEditor): Promise<void> {
 	colors.forEach((color, index) => {
 		editor.setDecorations(color, rangeLists[index])
 	})
+
+	return true
 }

--- a/src/editorDebounce.ts
+++ b/src/editorDebounce.ts
@@ -1,18 +1,21 @@
 import * as vscode from 'vscode'
 
-type EditorFunction = (editor: vscode.TextEditor) => void
+type EditorFunction = (editor: vscode.TextEditor) => Promise<boolean>
 
-export function debounce(func: EditorFunction, delay: number): EditorFunction {
+export function debounce(func: EditorFunction, delay: number): (editor: vscode.TextEditor) => void {
     const lastExecutionTimes = new Map<string, number>()
 
-    return (editor: vscode.TextEditor) => {
+    return async (editor: vscode.TextEditor) => {
         const now = Date.now()
         const key = editor.document.uri.toString()
         const lastExecution = lastExecutionTimes.get(key) || 0
 
         if (now - lastExecution >= delay) {
-            func(editor)
-            lastExecutionTimes.set(key, now)
+            if (await func(editor)) {
+                lastExecutionTimes.set(key, now)
+            } else {
+                setTimeout(() => debounce(func, delay)(editor), delay)
+            }
         }
     }
 }

--- a/src/editorDebounce.ts
+++ b/src/editorDebounce.ts
@@ -1,0 +1,18 @@
+import * as vscode from 'vscode'
+
+type EditorFunction = (editor: vscode.TextEditor) => void
+
+export function debounce(func: EditorFunction, delay: number): EditorFunction {
+    const lastExecutionTimes = new Map<string, number>()
+
+    return (editor: vscode.TextEditor) => {
+        const now = Date.now()
+        const key = editor.document.uri.toString()
+        const lastExecution = lastExecutionTimes.get(key) || 0
+
+        if (now - lastExecution >= delay) {
+            func(editor)
+            lastExecutionTimes.set(key, now)
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses two issues:
1. Only the active editor was colorized when opening a workspace with multiple editors.
2. Editors could lose colorization during certain operations.

Changes:
- Modified extension to colorize all visible editors, both on workspace open and during editor changes.
- Implemented a custom, editor-aware debounce function to replace 'just-debounce'.

Note: Removed 'just-debounce' from dependencies, updating package.json.