### PR TITLE
Fix colors resetting when modifying `settings.json` via `Quick fix...`

### DIFF
--- a/src/colorize.ts
+++ b/src/colorize.ts
@@ -6,7 +6,7 @@ import { colors, ignoredLanguages, method, Method, bigFileSize } from "./configu
 let rangeLists: vscode.Range[][] = colors.map(_ => [])
 
 function colorIndexOfSymbol(symbolName: string, symbolIndex: number): number {
-	switch(method) {
+	switch (method) {
 		case Method.hash:
 			return murmurhash.v3(symbolName) % rangeLists.length
 		case Method.sequential:
@@ -17,12 +17,11 @@ function colorIndexOfSymbol(symbolName: string, symbolIndex: number): number {
 
 export async function colorize(editor: vscode.TextEditor): Promise<boolean> {
 	const uri = editor.document.uri
-	if (uri == null || ignoredLanguages.has(editor.document.languageId)) { return true }
+	if (uri == null || ignoredLanguages.has(editor.document.languageId) || uri.scheme === "git") { return true }
 	const stat = await vscode.workspace.fs.stat(uri)
 	if (stat.size > bigFileSize) { return true }
 	const legend: vscode.SemanticTokensLegend | undefined = await vscode.commands.executeCommand('vscode.provideDocumentSemanticTokensLegend', uri)
 	const tokensData: vscode.SemanticTokens | undefined = await vscode.commands.executeCommand('vscode.provideDocumentSemanticTokens', uri)
-	vscode.window.activeColorTheme
 	rangeLists = colors.map(_ => [])
 	if (tokensData == null || legend == null) { return false }
 	const rangesBySymbolName = rangesByName(tokensData, legend, editor)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,9 +6,11 @@ import { generatePalette } from "./configuration"
 
 const colorizeIfNeeded = debounce((editor: vscode.TextEditor) => colorize(editor), 200)
 
-interface SemanticToken {
-	name: string
-	range: vscode.Range
+function handleBackgroundConfigurationChange() {
+	const editors = vscode.window.visibleTextEditors
+	editors.forEach(editor => {
+		colorizeIfNeeded(editor)
+	})
 }
 
 function handleVisibleEditorsChange(editors: readonly vscode.TextEditor[]) {
@@ -35,6 +37,7 @@ function handleTextDocumentChange(event: vscode.TextDocumentChangeEvent) {
 export function activate(context: vscode.ExtensionContext) {
 	updateConfiguration()
 	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(updateConfiguration))
+	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(handleBackgroundConfigurationChange))
 	context.subscriptions.push(vscode.window.onDidChangeVisibleTextEditors(handleVisibleEditorsChange))
 	context.subscriptions.push(vscode.workspace.onDidChangeTextDocument(handleTextDocumentChange))
 	context.subscriptions.push(vscode.window.onDidChangeActiveColorTheme(handleColorThemeChange))
@@ -45,4 +48,4 @@ export function activate(context: vscode.ExtensionContext) {
 	})
 }
 
-export function deactivate() {}
+export function deactivate() { }


### PR DESCRIPTION
Follow-up to #19, better to merge after that one

Details are in #18.

The idea is to listen for config changes and always reapply coloring